### PR TITLE
fix: error on setting upstream

### DIFF
--- a/create-gitops-pull-request.sh
+++ b/create-gitops-pull-request.sh
@@ -39,7 +39,7 @@ kustomize edit set image docker.io/"${DOCKER_REPOSITORY}":"${CIRCLE_SHA1}"
 hub add kustomization.yaml
 
 # Commit with sign-off
-hub commit -s -m "changed ""${SERVICE}""" image tag to "${CIRCLE_SHA1}"
+hub commit -s -m "changed ${SERVICE} image tag to ${CIRCLE_SHA1}"
 
 # Push branch to origin
 hub push --set-upstream origin update-image-"${SERVICE}"-"${CIRCLE_SHA1}"


### PR DESCRIPTION
```
Switched to a new branch 'update-image-reaction-authorization-de254cfd4369d2a7cc3311b167d3f97e81b28505'
error: pathspec 'image' did not match any file(s) known to git.
error: pathspec 'tag' did not match any file(s) known to git.
error: pathspec 'to' did not match any file(s) known to git.
error: pathspec 'de254cfd4369d2a7cc3311b167d3f97e81b28505' did not match any file(s) known to git.
Exited with code 1
```

Fixed above error when you push the updated image