### PR TITLE
fix: refrain from erroring if no dockerfiles are present

### DIFF
--- a/lint-dockerfiles.sh
+++ b/lint-dockerfiles.sh
@@ -13,7 +13,7 @@ set -o posix    # more strict failures in subshells
 IFS="$(printf "\n\t")"
 # ---- End unofficial bash strict mode boilerplate
 
-git ls-files | grep -E '(^|/)Dockerfile$' | {
+git ls-files | grep -E '(^|/)Dockerfile$' || true | {
   while IFS= read -r file_path; do
     echo -n "hadolint ${file_path} "
     docker run --rm --interactive hadolint/hadolint:v1.16.3 hadolint /dev/stdin <"${file_path}"


### PR DESCRIPTION
This gracefully handles when no dockerfiles are found.