### PR TITLE
feat: Use HEAD as default git ref for docker-tags

### DIFF
--- a/docker-tags.sh
+++ b/docker-tags.sh
@@ -1,8 +1,20 @@
-#!/bin/bash
-# outputs each tag we're attaching to this docker image
-set -e
+#!/usr/bin/env bash
 
-SHA=$1
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+# outputs each tag we're attaching to this docker image
+SHA="${1:-HEAD}"
 BRANCH=$2
 SHA1=$(git rev-parse --verify "${SHA}")
 
@@ -21,9 +33,10 @@ if [[ -n "${BRANCH}" ]]; then
 fi
 
 # Tag with each git tag
-git show-ref --tags -d | grep "^${SHA1}" | sed -e 's,.* refs/tags/,,' -e 's/\^{}//' 2>/dev/null |
-  xargs -I % \
-    echo "%"
+git show-ref --tags -d |
+  grep "^${SHA1}" |
+  sed -e 's,.* refs/tags/,,' -e 's/\^{}//' 2>/dev/null |
+  xargs -I % echo "%"
 
 # Tag with latest if certain conditions are met
 if [[ "$BRANCH" == "master" || "$BRANCH" == "trunk" || "$BRANCH" == "release-latest" ]]; then


### PR DESCRIPTION
- Add unofficial bash strict mode boilerplate
- style: format pipelines as per google shell style guide

---

**Note** @rosshadden I don't think this fixes #47 but I'm not able to confirm/reproduce that using reactioncommerce/reaction `chore-release-3.0.0-alpha.3` branch at the moment.