### PR TITLE
chore: fix semantic-release branches configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "release": {
-    "branch": "trunk"
+    "branches": ["trunk"]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Previous release failed. Semantic release must have been configured incorrectly all along or maybe they just did a breaking change. Not sure, but this repo has published many releases before and suddenly things stopped working.